### PR TITLE
Fix(github): Trigger Docker publish workflow on all branches

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ] # Triggers the workflow on push events to the main branch
+    branches: [ "**" ] # Triggers the workflow on push events to all branches
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
I've modified .github/workflows/docker-publish.yml to change the push trigger from only the 'main' branch to all branches ('**').

This will allow the Docker image to be built and pushed to Docker Hub on every commit pushed to any branch in the repository, as you requested.